### PR TITLE
Added support for booting using bundle

### DIFF
--- a/nx-os/poap/poap.py
+++ b/nx-os/poap/poap.py
@@ -39,52 +39,9 @@ Increasing the script timeout to handle the legacy nxos
 versions where upgrading will take time
 """
 # script_timeout=1800
+# For install_path YAML format, required keys, and sample file,
+# see readme.md -> "Optional YAML-driven install flow (install_path)".
 # --- Start of user editable settings ---
-# Host name and user credential
-# Add the install_path option to install licenses, rpms,
-# and certificates through script from the path mentioned. 
-# A file named <serial-number>.yaml is to be placed inside a folder named serial-number
-# which has details of files to be installed for the particular box.
-# eg. if option added is "install_path" : "/tftpboot/"
-# expected file is /tftpboot/<serial-number>/<serial-number>.yaml
-# Keywords to be used are Version, License, RPM, Certificate and Trustpoint.
-# Version is a mandatory keyword and it should be 1 for this release.
-# License : All the license files to be installed need to be listed in this
-# section in proper yaml syntax. Path should be relative to install_path
-# RPM : All rpm files to be installed need to be listed in this section in
-# proper yaml syntax. Path should be relative to install_path
-# Certificate: All certificate files and public key files which do not have a
-# trustpoint associated need to be listed in this section in proper yaml syntax.
-# These will only be copied to bootflash/poap_files/
-# Trustpoint : All pkcs12 certificates obtained from CA and which need trustpoint to be
-# configured need to be listed against the correct CA-trustpoint name for 
-# the same certificate with passphrase in proper yaml syntax.
-#
-# Sample YAML file (name XYZ12345.yaml)
-# ----------------------------------------------------------------------------
-# Version: 1
-# Certificate:
-# - ssh_key1.pub
-# - XYZ12345/nxapi_server_key.pem
-# - XYZ12345/nxapi_server_cert.pem
-# License:
-# - XYZ12345/XYZ12345_1.lic
-# - XYZ12345_2.lic
-# RPM:
-# - POAP_TPARTY_AND_PATCH_RPMS/chef-12.19.33-1.nexus7.x86_64.rpm
-# - mtx-openconfig-vlan-1.0.0.206-9.3.5.lib32_n9000.rpm
-# - POAP_TPARTY_AND_PATCH_RPMS/nxos.POAP_SMU_BGP_RELOAD-n9k_ALL-1.0.0-9.3.5.lib32_n9000.rpm
-# Target_image: nxos.9.3.5.bin
-# Trustpoint:
-#   Z1_TP:
-#     POAP_TP_FILES/XYZ12345/Z1_TP.pfx: passphrase1
-#   Z2_TP:
-#     POAP_TP_FILES/XYZ12345/Z2_TP.p12: passphrase2
-# ----------------------------------------------------------------------------
-# Additionally a "Target_image" can also be defined in .yaml file for a box to override the
-# target image for that specific box as opposed to the target_system_image given as common to all boxes
-# through script. If Target_image mentioned in yaml then that image should be kept only in 
-# target_system_image path mentioned within poap script. No relative path support for Target_image in yaml file
 
 options = {
    "username": "root",
@@ -93,6 +50,7 @@ options = {
    "transfer_protocol": "scp",
    "mode": "serial_number",
    "target_system_image": "nxos.9.3.1.bin",
+   "bundle_name": "",
 }
 
 """
@@ -372,6 +330,7 @@ def set_defaults_and_validate_options():
     set_default("source_tarball", "personality.tar")
     set_default("destination_tarball", options["source_tarball"])
     set_default("compact_image", False)
+    set_default("bundle_name", "")
 
     # Check that options are valid
     validate_options()
@@ -772,6 +731,39 @@ def split_config_not_needed():
     # NXOS 7.0.3.I3 or less
     return False
 
+
+def is_bundle_supported():
+    """
+    Checks if the image supports bundle or not. If target image is greater
+    than or equal to 10.7(1) then bundle is supported. 
+    Typical image format is nxos.10.7.1.I1.bin or nxos64-cs.10.7.1.bin for bundle supporting images.
+    """
+
+    parts = options['target_system_image'].split(".")
+    if len(parts) < 5:
+        return False
+
+    if "nxos" not in parts[0]:
+        return False
+
+    try:
+        nxos_major = int(parts[1])
+        if nxos_major > 10:
+            return True
+        elif nxos_major < 10:
+            return False
+    except ValueError:
+        return False
+
+    try:
+        nxos_minor = int(parts[2])
+        if nxos_minor >= 7:
+            return True
+        elif nxos_minor < 7:
+            return False
+    except ValueError:
+        return False
+
 def mtc_shut_member_ports(line, config_file_first):
     """
     In case bundling of any ports is done for mtc we shut down all the member
@@ -1157,16 +1149,26 @@ def do_copy(source="", dest="", login_timeout=10, dest_tmp="", compact=False, do
                 elif "no such file" in str(e):
                     if (dont_abort == True):
                         poap_log("Copy Failed. File/Directory not found")
-                        pass
+                        return False
                     else:
                         abort("Copy of %s failed: no such file" % source)
                 elif "Permission denied" in str(e):
-                    abort("Copy of %s failed: permission denied" % source)
+                    if (dont_abort == True):
+                        poap_log("Copy Failed. Permission denied")
+                        return False
+                    else:
+                        abort("Copy of %s failed: permission denied" % source)
                 elif "No space left on device" in str(e):
                     abort("Copy failed: No space left on device")
                 else:
                     poap_log("Copy failed: %s" % str(e))
                     raise
+    
+    if not os.path.exists(dest_tmp):
+        if dont_abort == True:
+            poap_log("Copy did not create temporary file: %s" % dest_tmp)
+            return False
+        abort("Copy failed: temporary file missing (%s)" % dest_tmp)
 
     try:
         file_size = os.path.getsize(dest_tmp)
@@ -1631,6 +1633,9 @@ def parse_poap_yaml():
     """
     Parses the <serial_number>.yaml file and populates the dictionary
     """
+    if not options.get("serial_number"):
+        abort("Serial number is not provided. Cannot parse yaml file for device.")
+    
     copy_path = options["install_path"] + "/" + options["serial_number"] + "/" + options["serial_number"] + ".yaml"
     alt_path = options["install_path"] + "/" + options["serial_number"] + "/" + options["serial_number"] + ".yml"
     timeout = options["timeout_copy_system"]
@@ -1964,7 +1969,7 @@ def verify_freespace():
         abort("*** Not enough bootflash space to continue POAP ***")
 
 
-def set_cfg_file_serial():
+def set_cfg_file_serial(bundle=0):
     """
     Sets the name of the switch config file to download based on chassis
     serial number. e.g conf_FOC3825R1ML.cfg
@@ -1973,12 +1978,15 @@ def set_cfg_file_serial():
 
     if 'POAP_SERIAL' in os.environ:
         poap_log("serial number %s" % os.environ['POAP_SERIAL'])
-        options["source_config_file"] = "conf.%s" % os.environ['POAP_SERIAL']
+        if bundle == 0:
+            options["source_config_file"] = "conf.%s" % os.environ['POAP_SERIAL']
+        else:
+            options["bundle_name"] = "%s" % os.environ['POAP_SERIAL']
         options["serial_number"] = os.environ['POAP_SERIAL']
     poap_log("Selected conf file name : %s" % options["source_config_file"])
 
 
-def set_cfg_file_mac():
+def set_cfg_file_mac(bundle=0):
     """
     Sets the name of the switch config file to download based on interface
     MAC address. e.g conf_7426CC5C9180.cfg
@@ -1987,30 +1995,61 @@ def set_cfg_file_mac():
     if os.environ.get("POAP_PHASE", None) == "USB":
         if options["usb_slot"] == 2:
             poap_log("usb slot is 2")
-
-        config_file = "conf_%s.cfg" % os.environ['POAP_RMAC']
+        
         options["serial_number"] = os.environ['POAP_RMAC']
-        poap_log("Router MAC conf file name : %s" % config_file)
-        if os.path.exists("/usbslot%d/%s" % (usbslot, config_file)):
-            options["source_config_file"] = config_file
-            poap_log("Selected conf file name : %s" % options["source_config_file"])
-            return
-        config_file = "conf_%s.cfg" % os.environ['POAP_MGMT_MAC']
+        if bundle == 0:
+            config_file = "conf_%s.cfg" % os.environ['POAP_RMAC']
+            poap_log("Router MAC conf file name : %s" % config_file)
+            if os.path.exists("/usbslot%d/%s" % (options["usb_slot"], config_file)):
+                options["source_config_file"] = config_file
+                poap_log("Selected conf file name : %s" % options["source_config_file"])
+                return
+            else:
+                poap_log("Config file with Router MAC not found in usb. Looking for config file with MGMT MAC")
+        else:
+            bundle_name = "%s" % os.environ['POAP_RMAC']
+            if os.path.exists("/usbslot%d/%s.tar" % (options["usb_slot"], bundle_name)) or \
+               os.path.exists("/usbslot%d/%s.tgz" % (options["usb_slot"], bundle_name)):
+                options["bundle_name"] = bundle_name
+                poap_log("Selected bundle name : %s" % options["bundle_name"])
+                return
+            else:
+                poap_log("Bundle with Router MAC not found in usb. Looking for bundle with MGMT MAC")
+        
         options["serial_number"] = os.environ['POAP_MGMT_MAC']
-        poap_log("MGMT MAC conf file name : %s" % config_file)
-        if os.path.exists("/usbslot%d/%s" % (options["usb_slot"], config_file)):
-            options["source_config_file"] = config_file
-            poap_log("Selected conf file name : %s" % options["source_config_file"])
-            return
+        if bundle == 0:
+            config_file = "conf_%s.cfg" % os.environ['POAP_MGMT_MAC']
+            poap_log("MGMT MAC conf file name : %s" % config_file)
+            if os.path.exists("/usbslot%d/%s" % (options["usb_slot"], config_file)):
+                options["source_config_file"] = config_file
+                poap_log("Selected conf file name : %s" % options["source_config_file"])
+                return
+            else:
+                poap_log("Config file with MGMT MAC not found in usb.")
+                abort("Config file not found in usb. Please make sure the config file is named with either Router MAC or MGMT MAC and is present in the usb drive.")
+        else: 
+            bundle_name = "%s" % os.environ['POAP_MGMT_MAC']
+            if os.path.exists("/usbslot%d/%s.tar" % (options["usb_slot"], bundle_name)) or \
+               os.path.exists("/usbslot%d/%s.tgz" % (options["usb_slot"], bundle_name)):
+                options["bundle_name"] = bundle_name
+                poap_log("Selected bundle name : %s" % options["bundle_name"])
+                return
+            else:
+                poap_log("Bundle with MGMT MAC not found in usb.")
+                abort("Bundle not found in usb. Please make sure the bundle is named with either Router MAC or MGMT MAC and is present in the usb drive.")
     else:
         if 'POAP_MAC' in os.environ:
             poap_log("Interface MAC %s" % os.environ['POAP_MAC'])
-            options["source_config_file"] = "conf_%s.cfg" % os.environ['POAP_MAC']
+            if bundle == 0:
+               options["source_config_file"] = "conf_%s.cfg" % os.environ['POAP_MAC']
+               poap_log("Selected conf file name : %s" % options["source_config_file"])
+            else:
+               options["bundle_name"] = "%s" % os.environ['POAP_MAC']
+               poap_log("Selected bundle name : %s" % options["bundle_name"])
             options["serial_number"] = os.environ['POAP_MAC']
-            poap_log("Selected conf file name : %s" % options["source_config_file"])
+            
 
-
-def set_cfg_file_host():
+def set_cfg_file_host(bundle=0):
     """
     Sets the name of the switch config file to download based on hostname
     received in the DHCP option. e.g conf_TestingSw.cfg
@@ -2018,16 +2057,23 @@ def set_cfg_file_host():
     poap_log("Setting source cfg filename based on switch hostname")
     if 'POAP_HOST_NAME' in os.environ:
         poap_log("Host Name: [%s]" % os.environ['POAP_HOST_NAME'])
-        options["source_config_file"] = "conf_%s.cfg" % os.environ['POAP_HOST_NAME']
+        if bundle == 0:
+            options["source_config_file"] = "conf_%s.cfg" % os.environ['POAP_HOST_NAME']
+            poap_log("Selected conf file name : %s" % options["source_config_file"])
+        else:
+            options["bundle_name"] = "%s" % os.environ['POAP_HOST_NAME']
+            poap_log("Selected bundle name : %s" % options["bundle_name"])
     else:
         poap_log("Host Name information missing, falling back to static mode")
-    poap_log("Selected conf file name : %s" % options["source_config_file"])
+    
 
 
-def set_cfg_file_location():
+def set_cfg_file_location(bundle=0):
     """
     Sets the name of the switch config file to download based on cdp
     information. e.g conf_switch_Eth1_32.cfg
+    bundle parameter is used to differentiate between config file name and bundle name. 
+    If bundle is 0, config file name is set. If bundle is 1, bundle name is set.
     """
     poap_log("Setting source cfg filename")
     poap_log("show cdp neighbors interface %s" % os.environ['POAP_INTF'])
@@ -2074,10 +2120,15 @@ def set_cfg_file_location():
     else:
         # 3K 6x and older releases don't print this info
         intf_name = cdp_info[-1]
-
-    options["source_config_file"] = "conf_%s_%s.cfg" % (switch_name, intf_name)
-    options["source_config_file"] = options["source_config_file"].replace("/", "_")
-    poap_log("Selected conf file name : %s" % options["source_config_file"])
+    
+    if bundle == 0:
+        options["source_config_file"] = "conf_%s_%s.cfg" % (switch_name, intf_name)
+        options["source_config_file"] = options["source_config_file"].replace("/", "_")
+        poap_log("Selected conf file name : %s" % options["source_config_file"])
+    else:
+        options["bundle_name"] = "%s_%s" % (switch_name, intf_name)
+        options["bundle_name"] = options["bundle_name"].replace("/", "_")
+        poap_log("Selected bundle name : %s" % options["bundle_name"])
 
 
 def get_version(option=0):
@@ -2494,8 +2545,9 @@ def setup_mode():
     elif options["mode"] == "mac":
         set_cfg_file_mac()
     elif options["mode"] == "hostname":
+        if 'POAP_SERIAL' in os.environ:
+            options["serial_number"] = os.environ['POAP_SERIAL']
         set_cfg_file_host()
-        options["serial_number"] = os.environ['POAP_SERIAL']
     elif options["mode"] == "personality":
         initialize_personality()
     elif options["mode"] == "raw":
@@ -2585,8 +2637,157 @@ def cleanup_temp_images():
         remove_file(midway_system)
 
 
+def determine_bundle_name():
+    """
+    Determines the name of the bundle that POAP script should look for, 
+    based on the input. 
+    If bundle name is explicity mentioned, try copying that else derive the bundle
+    name based on the provided option. Options are same as input of mode. 
+    """
+    allowed_bundle_options = ["location", "serial_number", "mac", "hostname"]
+    if options["bundle_name"] in allowed_bundle_options:
+        poap_log("Deriving bundle name based on the option %s" % options["bundle_name"])
+        if options["bundle_name"] == "location":
+            set_cfg_file_location(bundle=1)
+            options["serial_number"] = os.environ['POAP_SERIAL']
+        elif options["bundle_name"] == "serial_number":
+            set_cfg_file_serial(bundle=1)
+        elif options["bundle_name"] == "mac":
+            set_cfg_file_mac(bundle=1)
+        elif options["bundle_name"] == "hostname":
+            set_cfg_file_host(bundle=1)
+    else:
+        poap_log("Using the provided bundle name %s" % options["bundle_name"])
+
+
+def check_feature_openconfig(file_path):
+    with open(file_path, 'r') as f:
+        for line in f:
+            if 'feature openconfig' in line:
+                return True
+    return False
+
+
+def process_bundle():
+    """
+    Processes the bundle for POAP deployment. Assumes bundle mode is supported and bundle name is determined.
+
+    Steps:
+    1. Creates/cleans the /bootflash/poap_pending/ directory
+    2. Attempts to copy bundle (tries .tar extension first, then .tgz if that fails)
+    3. Extracts the bundle to poap_pending directory
+    4. Searches for poap.cfg in extracted bundle (root, subdirectory, or nested locations)
+    5. Validates that the config contains 'feature openconfig' requirement
+    6. Moves the config file to the destination path for POAP processing
+
+    Returns:
+        True: Bundle processing successful, skip normal config copy in POAP flow
+        False: Bundle processing failed, proceed with normal POAP flow
+    
+    Note: Cleans up poap_pending directory on any failure
+    """
+    dest_path_base = "/bootflash/poap_pending/"
+    ret = False
+    
+    try:
+        if os.path.exists(dest_path_base):
+            poap_log("Cleaning existing bundle directory: %s" % dest_path_base)
+            if os.path.isdir(dest_path_base):
+                shutil.rmtree(dest_path_base)
+            else:
+                os.remove(dest_path_base)
+        os.makedirs(dest_path_base)
+    except OSError as e:
+        poap_log("Failed to create destination path for bundle: %s" % str(e))
+        return False
+    
+    # First try, with .tar extension
+    dest_bundle_path = os.path.join(dest_path_base, "%s.tar" % options["bundle_name"])
+    src_bundle_path = os.path.join(options["config_path"], options["bundle_name"] + '.tar')
+    tmp_file = dest_bundle_path + ".tmp"
+
+    do_copy(src_bundle_path, dest_bundle_path, options["timeout_config"], tmp_file, dont_abort=True)
+
+    if (os.path.exists(dest_bundle_path) and (os.path.getsize(dest_bundle_path) > 0)):
+        poap_log("Bundle copied successfully with .tar extension. Extracting the bundle now.")
+        try:
+            with tarfile.open(dest_bundle_path) as tar:
+                tar.extractall(dest_path_base)
+        except Exception as e:
+            poap_log("Failed to extract the bundle: %s" % str(e))
+            shutil.rmtree(dest_path_base, ignore_errors=True)
+            return False
+    else:
+        poap_log("Bundle with .tar extension not found. Trying with .tgz extension.")
+
+        # Try .tgz
+        dest_bundle_path = os.path.join(dest_path_base, "%s.tgz" % options["bundle_name"])
+        src_bundle_path = os.path.join(options["config_path"], options["bundle_name"] + ".tgz")
+        tmp_file = dest_bundle_path + ".tmp"
+
+        do_copy(src_bundle_path, dest_bundle_path, options["timeout_config"], tmp_file, dont_abort=True)
+
+        if (os.path.exists(dest_bundle_path) and (os.path.getsize(dest_bundle_path) > 0)):
+            poap_log("Bundle with .tgz extension copied successfully. Extracting the bundle now.")
+            try:
+                with tarfile.open(dest_bundle_path) as tar:
+                    tar.extractall(dest_path_base)
+            except Exception as e:
+                poap_log("Failed to extract the bundle: %s" % str(e))
+                shutil.rmtree(dest_path_base, ignore_errors=True)
+                return False
+        else:
+            poap_log("Bundle with .tgz extension also not found. Aborting bundle mode.")
+            shutil.rmtree(dest_path_base, ignore_errors=True)
+            return False        
+        
+
+    # Bundle extraction successful. Now locate the poap.cfg file within the extracted bundle.
+    # The config file may be at the root level, in a subdirectory, or nested deeper in the bundle.
+    # Once found, validate it contains 'feature openconfig' and move it to the destination path.
+    extracted_config_path = os.path.join(dest_path_base, "poap.cfg")
+    if not os.path.isfile(extracted_config_path):
+        bundle_subdir_config_path = os.path.join(dest_path_base, options["bundle_name"], "poap.cfg")
+        if os.path.isfile(bundle_subdir_config_path):
+            extracted_config_path = bundle_subdir_config_path
+        else:
+            extracted_config_path = None
+            for root, dirs, files in os.walk(dest_path_base):
+                if "poap.cfg" in files:
+                    extracted_config_path = os.path.join(root, "poap.cfg")
+                    break
+    
+    if extracted_config_path and os.path.isfile(extracted_config_path):
+        dest_config_path = os.path.join("/bootflash", options["split_config_second"])
+        try:
+            ret = check_feature_openconfig(extracted_config_path)
+            if ret == False:
+                poap_log("Feature openconfig is not supported on this config. Aborting bundle mode.")
+                shutil.rmtree(dest_path_base, ignore_errors=True)
+                return False
+            else:
+                try: 
+                    shutil.move(extracted_config_path, dest_config_path)
+                except Exception as e:
+                    poap_log("Failed to copy config file from the bundle to the config path: %s" % str(e))
+                    shutil.rmtree(dest_path_base, ignore_errors=True)
+                    return False
+                
+                poap_log("Config file copied successfully from the bundle. Bundle processing successful.")
+                return True
+        except Exception as e:
+            poap_log("Failed to copy config file from the bundle: %s" % str(e))
+            shutil.rmtree(dest_path_base, ignore_errors=True)
+            return False
+    else:
+        poap_log("Config file poap.cfg not found in the extracted bundle. Bundle corrupted. Aborting bundle mode.")
+        shutil.rmtree(dest_path_base, ignore_errors=True)
+        return False
+
 def main():
     signal.signal(signal.SIGTERM, sigterm_handler)
+    bundle_supported = False
+    bundle_successful = False
 
     # Set all the default parameters and validate the ones provided
     set_defaults_and_validate_options()
@@ -2606,12 +2807,22 @@ def main():
     # Now that we know we're going to try and copy, let's create
     # the directory structure needed, if any
     create_destination_directories()
-
+    
     check_multilevel_install()
     # In two step install we just copy the midway image and reboot.
     # Config copy and script download happens in the second step.
     if multi_step_install == False:
-        copy_config()
+        if options["bundle_name"] != "":
+            bundle_supported = is_bundle_supported()
+            if bundle_supported == False:
+                poap_log("Bundle not supported on current running image. Aborting bundle mode and proceeding with normal POAP flow.")
+            else:
+                poap_log("Bundle mode is supported. Proceeding with bundle installation.")
+                determine_bundle_name()
+                bundle_successful = process_bundle()
+        
+        if bundle_successful != True:
+            copy_config()
 
         # Download user scripts and agents
         download_scripts_and_agents()

--- a/nx-os/poap/poap.py
+++ b/nx-os/poap/poap.py
@@ -736,14 +736,22 @@ def is_bundle_supported():
     """
     Checks if the image supports bundle or not. If target image is greater
     than or equal to 10.7(1) then bundle is supported. 
-    Typical image format is nxos.10.7.1.I1.bin or nxos64-cs.10.7.1.bin for bundle supporting images.
+    Typical image format is nxos.10.7.1.I1.bin or nxos64-cs.10.7.1.F.bin for bundle supporting images.
     """
 
     parts = options['target_system_image'].split(".")
     if len(parts) < 5:
+        poap_log(
+            "Unable to determine if bundle is supported from given target image {}. "
+            "Assuming bundle is not supported.".format(options["target_system_image"])
+        )
         return False
 
     if "nxos" not in parts[0]:
+        poap_log(
+            "Unable to determine if bundle is supported from given target image {}. "
+            "Assuming bundle is not supported.".format(options["target_system_image"])
+        )
         return False
 
     try:
@@ -2661,11 +2669,43 @@ def determine_bundle_name():
 
 
 def check_feature_openconfig(file_path):
-    with open(file_path, 'r') as f:
-        for line in f:
-            if 'feature openconfig' in line:
-                return True
-    return False
+    try:
+        with open(file_path, 'r') as f:
+            for line in f:
+                if 'feature openconfig' in line:
+                    return True
+        return False
+    except (IOError, OSError, UnicodeDecodeError) as e:
+        poap_log("Failed to read config file: %s" % str(e))
+        return False
+
+
+def safe_extract_tar(tar_obj, destination):
+    """
+    Safely extracts tar members by preventing path traversal and unsafe entries.
+    """
+    destination_real = os.path.realpath(destination)
+    safe_members = []
+
+    for member in tar_obj.getmembers():
+        member_name = member.name
+
+        if member_name.startswith("/") or member_name.startswith("\\"):
+            raise ValueError("Tar contains absolute path entry: %s" % member_name)
+
+        target_path = os.path.realpath(os.path.join(destination_real, member_name))
+        if not (target_path == destination_real or target_path.startswith(destination_real + os.sep)):
+            raise ValueError("Tar contains path traversal entry: %s" % member_name)
+
+        if member.issym() or member.islnk():
+            raise ValueError("Tar contains link entry: %s" % member_name)
+
+        if not (member.isfile() or member.isdir()):
+            raise ValueError("Tar contains unsupported entry type: %s" % member_name)
+
+        safe_members.append(member)
+
+    tar_obj.extractall(destination_real, members=safe_members)
 
 
 def process_bundle():
@@ -2687,6 +2727,8 @@ def process_bundle():
     Note: Cleans up .poap_pending directory on any failure
     """
     dest_path_base = "/bootflash/.poap_pending/"
+    dest_config_file = "poap.cfg"
+
     ret = False
     
     try:
@@ -2712,7 +2754,7 @@ def process_bundle():
         poap_log("Bundle copied successfully with .tar extension. Extracting the bundle now.")
         try:
             with tarfile.open(dest_bundle_path) as tar:
-                tar.extractall(dest_path_base)
+                safe_extract_tar(tar, dest_path_base)
         except Exception as e:
             poap_log("Failed to extract the bundle: %s" % str(e))
             shutil.rmtree(dest_path_base, ignore_errors=True)
@@ -2731,7 +2773,7 @@ def process_bundle():
             poap_log("Bundle with .tgz extension copied successfully. Extracting the bundle now.")
             try:
                 with tarfile.open(dest_bundle_path) as tar:
-                    tar.extractall(dest_path_base)
+                    safe_extract_tar(tar, dest_path_base)
             except Exception as e:
                 poap_log("Failed to extract the bundle: %s" % str(e))
                 shutil.rmtree(dest_path_base, ignore_errors=True)
@@ -2745,16 +2787,16 @@ def process_bundle():
     # Bundle extraction successful. Now locate the poap.cfg file within the extracted bundle.
     # The config file may be at the root level, in a subdirectory, or nested deeper in the bundle.
     # Once found, validate it contains 'feature openconfig' and move it to the destination path.
-    extracted_config_path = os.path.join(dest_path_base, "poap.cfg")
+    extracted_config_path = os.path.join(dest_path_base, dest_config_file)
     if not os.path.isfile(extracted_config_path):
-        bundle_subdir_config_path = os.path.join(dest_path_base, options["bundle_name"], "poap.cfg")
+        bundle_subdir_config_path = os.path.join(dest_path_base, options["bundle_name"], dest_config_file)
         if os.path.isfile(bundle_subdir_config_path):
             extracted_config_path = bundle_subdir_config_path
         else:
             extracted_config_path = None
             for root, dirs, files in os.walk(dest_path_base):
-                if "poap.cfg" in files:
-                    extracted_config_path = os.path.join(root, "poap.cfg")
+                if dest_config_file in files:
+                    extracted_config_path = os.path.join(root, dest_config_file)
                     break
     
     if extracted_config_path and os.path.isfile(extracted_config_path):
@@ -2780,7 +2822,7 @@ def process_bundle():
             shutil.rmtree(dest_path_base, ignore_errors=True)
             return False
     else:
-        poap_log("Config file poap.cfg not found in the extracted bundle. Bundle corrupted. Aborting bundle mode.")
+        poap_log("Config file %s not found in the extracted bundle. Bundle corrupted. Aborting bundle mode." % dest_config_file)
         shutil.rmtree(dest_path_base, ignore_errors=True)
         return False
 

--- a/nx-os/poap/poap.py
+++ b/nx-os/poap/poap.py
@@ -2673,9 +2673,9 @@ def process_bundle():
     Processes the bundle for POAP deployment. Assumes bundle mode is supported and bundle name is determined.
 
     Steps:
-    1. Creates/cleans the /bootflash/poap_pending/ directory
+    1. Creates/cleans the /bootflash/.poap_pending/ directory
     2. Attempts to copy bundle (tries .tar extension first, then .tgz if that fails)
-    3. Extracts the bundle to poap_pending directory
+    3. Extracts the bundle to the target directory
     4. Searches for poap.cfg in extracted bundle (root, subdirectory, or nested locations)
     5. Validates that the config contains 'feature openconfig' requirement
     6. Moves the config file to the destination path for POAP processing
@@ -2684,9 +2684,9 @@ def process_bundle():
         True: Bundle processing successful, skip normal config copy in POAP flow
         False: Bundle processing failed, proceed with normal POAP flow
     
-    Note: Cleans up poap_pending directory on any failure
+    Note: Cleans up .poap_pending directory on any failure
     """
-    dest_path_base = "/bootflash/poap_pending/"
+    dest_path_base = "/bootflash/.poap_pending/"
     ret = False
     
     try:

--- a/nx-os/poap/readme.md
+++ b/nx-os/poap/readme.md
@@ -1,0 +1,248 @@
+# Nexus 9000 POAP Script (`poap.py`)
+
+This repository contains a Python-based POAP (PowerOn Auto Provisioning) workflow for Cisco Nexus platforms. The script automates first-boot provisioning, including config download, image handling, optional multi-step upgrades, and optional post-provision package installation (licenses/RPMs/certificates).
+
+## What this script does
+
+`poap.py` performs the following high-level flow:
+
+1. Validates and applies default `options`.
+2. Initializes logging and syslog prefixing.
+3. Selects provisioning mode (`serial_number`, `mac`, `hostname`, `location`, `personality`, `raw`).
+4. Verifies bootflash free space and prepares destination directories.
+5. Handles optional bundle workflow (on supported target images).
+6. Copies/validates configuration and splits it when required for older image behavior.
+7. Copies optional user apps/scripts.
+8. Optionally parses per-device YAML and schedules license/RPM/certificate operations.
+9. Copies system (and kickstart if needed), installs image, and schedules config replay.
+
+---
+
+## Editable configuration
+
+User-editable settings are at the top of `poap.py` in the `options` dictionary and global flags.
+
+### Minimal required options (remote POAP)
+
+- `username`
+- `password`
+- `hostname`
+- `transfer_protocol`
+- `mode`
+- `target_system_image` (not required in `personality` mode)
+
+### Important defaults and options
+
+- `mode` (default: `serial_number`)
+- `transfer_protocol` (default: `scp`)
+- `config_path` (default: `/var/lib/tftpboot/`)
+- `target_image_path` (default: `/var/lib/tftpboot/`)
+- `target_system_image`, `target_kickstart_image`
+- `destination_path` (default: `/bootflash/`)
+- `required_space` (KB)
+- `disable_md5` (default: `False`)
+- `https_ignore_certificate` (for HTTPS copy)
+- `compact_image` (compact SCP image copy)
+- `skip_multi_level`, `midway_system_image`, `midway_kickstart_image`
+- `bundle_name` (bundle mode trigger when non-empty)
+- `install_path` (enables YAML-driven License/RPM/Certificate flow)
+- `user_app_path` (for `download_scripts_and_agents()` content)
+- `usb_slot`, `source_config_file`, `vrf`
+
+### Global behavior flags
+
+- `global_use_kstack = False`
+- `global_upgrade_bios = False`
+- `global_copy_image = True`
+
+---
+
+### Config file naming based on the supported modes
+
+- **serial_number**: `conf.<POAP_SERIAL>`
+- **mac**: `conf_<POAP_MAC>.cfg` (USB mode includes router/mgmt MAC fallback behavior)
+- **hostname**: `conf_<POAP_HOST_NAME>.cfg`
+- **location**: `conf_<cdp_switch>_<cdp_interface>.cfg`
+- **raw**: uses `source_config_file` as-is
+- **personality**: downloads personality tarball and derives target image from tar contents
+
+---
+
+## Integrity checks
+
+By default, MD5 validation is enabled for downloaded artifacts (config, images, tarballs, YAML recipe where applicable).
+
+- If `disable_md5` is `False`, the script attempts to copy corresponding `.md5` files and verify checksums.
+- If checksums fail, provisioning aborts.
+
+---
+
+## Optional YAML-driven install flow (`install_path`)
+
+If `install_path` is set and mode is not `personality`, the script tries to load a per-device YAML file:
+
+- `<install_path>/<serial>/<serial>.yaml` (fallback to `.yml`)
+
+This YAML supports:
+
+- `Version` (must be `1`)
+- `Target_image` (optional override of common target image)
+- `License` (list of `.lic` files)
+- `RPM` (list of `.rpm` files)
+- `Certificate` (list of cert/key files copied to `bootflash/poap_files`)
+- `Trustpoint` (map of trustpoint name -> `{pkcs12_file: passphrase}`)
+
+The script validates extensions, copies artifacts, and appends install commands to scheduled config where needed.
+
+### YAML file location and behavior
+
+When `install_path` is configured, POAP expects a per-device YAML recipe at:
+
+- `<install_path>/<serial-number>/<serial-number>.yaml`
+- Fallback: `<install_path>/<serial-number>/<serial-number>.yml`
+
+Example:
+
+- If `install_path` is `/tftpboot/`
+- Expected file for a device is `/tftpboot/<serial-number>/<serial-number>.yaml`
+
+If the file is present and valid, POAP uses it to schedule per-device package and certificate operations.
+If the file is missing, POAP logs that condition and continues with legacy POAP workflow.
+
+### YAML keys and expectations
+
+- `Version`
+  - Mandatory key
+  - Must be set to `1` for this release
+- `License`
+  - List of `.lic` files
+  - Paths must be relative to `install_path`
+- `RPM`
+  - List of `.rpm` files
+  - Paths must be relative to `install_path`
+- `Certificate`
+  - List of certificate/public-key files without trustpoint import
+  - These are copied to `bootflash/poap_files/`
+- `Trustpoint`
+  - Trustpoint map with PKCS12 file and passphrase
+  - Supported PKCS12 extensions are `.pfx` and `.p12`
+- `Target_image`
+  - Optional per-device override of common `target_system_image`
+  - Must be image filename only (no relative path support)
+  - The image must be available under `target_image_path`
+
+### Sample YAML file
+
+Sample filename: `XYZ12345.yaml`
+
+```yaml
+Version: 1
+Certificate:
+  - ssh_key1.pub
+  - XYZ12345/nxapi_server_key.pem
+  - XYZ12345/nxapi_server_cert.pem
+License:
+  - XYZ12345/XYZ12345_1.lic
+  - XYZ12345_2.lic
+RPM:
+  - POAP_TPARTY_AND_PATCH_RPMS/chef-12.19.33-1.nexus7.x86_64.rpm
+  - mtx-openconfig-vlan-1.0.0.206-9.3.5.lib32_n9000.rpm
+  - POAP_TPARTY_AND_PATCH_RPMS/nxos.POAP_SMU_BGP_RELOAD-n9k_ALL-1.0.0-9.3.5.lib32_n9000.rpm
+Target_image: nxos.9.3.5.bin
+Trustpoint:
+  Z1_TP:
+    POAP_TP_FILES/XYZ12345/Z1_TP.pfx: passphrase1
+  Z2_TP:
+    POAP_TP_FILES/XYZ12345/Z2_TP.p12: passphrase2
+```
+
+---
+
+## Bundle mode
+
+When `bundle_name` is non-empty, the script attempts bundle workflow if supported:
+
+- Support check is based on target image parsing (script logic expects bundle support from `>= 10.7(1)` style target image naming).
+- Tries `<bundle>.tar`, then `<bundle>.tgz` from `config_path`.
+- Extracts into `/bootflash/poap_pending/`.
+- Requires `poap.cfg` in bundle and checks for `feature openconfig` before using it.
+
+If bundle fails or unsupported, script falls back to normal config copy workflow.
+
+---
+
+## Multi-step upgrade flow (`multi_step_install`)
+
+### Why this exists
+
+Some upgrade paths cannot jump directly from the current image to the final target image (taking into account the ISSU matrix). In those cases, the `midway_system_image` needs to be populated by the user. 
+
+
+### When `multi_step_install` becomes active
+
+- If `midway_system_image` are configured and the switch is not already booted on that midway image.
+
+### What happens in practice
+
+1. **First POAP run (staged image run):**
+  - Script focuses on image copy/install for the midway image.
+  - It skips normal config/bundle/user-app/YAML install tasks in this pass.
+  - It sets boot variables and triggers write erase/reboot behavior so POAP runs again.
+
+2. **Second POAP run (final provisioning run):**
+  - Script continues normal workflow (config copy, optional bundle, optional YAML-driven installs, final image actions).
+  - It applies scheduled configuration as part of the normal completion path.
+
+### Operator controls
+
+- `midway_system_image` allow explicit control of the intermediate hop.
+
+---
+
+## USB behavior
+
+When `POAP_PHASE=USB`:
+
+- Remote credentials are not required.
+- Copy source paths use `/usbslot<usb_slot>/...`.
+- Personality mode is not supported over USB.
+
+---
+
+## Logs and cleanup
+
+- Runtime logs are written under `/bootflash/*poap*script.log`.
+- Script keeps the most recent 4 POAP logs.
+- On abort, cleanup and rollback paths attempt to remove temporary files and revert scheduled RPM/license/certificate changes where possible.
+
+---
+
+## Updating script integrity hash
+
+The script header contains an internal MD5 comment (`#md5sum="..."`).
+If the script is modified, regenerate this value using the command in the script header comments.
+
+The following command is for bash-shell. 
+
+```bash
+f=poap_nexus_script.py ; cat $f | sed '/^#md5sum/d' > $f.md5 ; sed -i \
+"s/^#md5sum=.*/#md5sum=\"$(md5sum $f.md5 | sed 's/ .*//')\"/" $f
+```
+
+---
+
+## Typical customization checklist
+
+1. Edit the top-level `options` dictionary for your environment.
+2. Set `mode` to match your config naming strategy.
+3. Verify `config_path`, `target_image_path`, and protocol credentials.
+4. Decide whether to keep MD5 verification enabled.
+5. (Optional) Enable `install_path` and create per-device YAML recipes.
+6. (Optional) Customize `download_scripts_and_agents()` for user agents/scripts.
+
+---
+
+## Notes
+
+- This script is intended to run in the NX-OS POAP environment where POAP-specific environment variables and Cisco CLI bindings are available.
+- It is not a generic standalone Python provisioning tool.


### PR DESCRIPTION
Initial PR for feature - for booting using bundle, to be brought in nxos 10.7(x) onwards. 

**SUMMARY:** 
This PR introduces bundle-based config ingestion flow for POAP. Please check the relevant functions for more details.

Key changes and new functions added: : 
1. New optional option in options dictionary - bundle_name
2. Helper functions for bundle - 
    a. is_bundle_supported 
    b. determine_bundle_name
    c. process_bundle
    d. check_feature_openconfig

It also migrates documentation from code comments into a dedicated README. 